### PR TITLE
Full node guide: use site vars for chain size

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -209,21 +209,21 @@ kramdown:
     coderay_css: style
 
 text:
-  ## Values last updated 2015-08-26
+  ## Values last updated 2015-12-29
   ## All variable names must indicate unit type for easy translation of adjacent text,
   ##   such as: subsidy_in_decimal_bitcoins or
   ##   bitcoin_org_docs_maintainer_email_link
   subsidy_in_decimal_bitcoins: 25
-  chain_gb: 50
-  bitcoin_datadir_gb: 60
-  bitcoin_datadir_gb_pruned: 3
-  total_tx_count_in_millions: 40
+  chain_gb: 60
+  bitcoin_datadir_gb: 80
+  bitcoin_datadir_gb_pruned: 5
+  total_tx_count_in_millions: 100
   typical_ibd_time_in_hours: 4
   typical_144_block_catchup_time_in_minutes: 5
   bitcoin_org_docs_maintainer_email_link: '<a href="mailto:dave@dtrt.org">Dave Harding</a>'
   ## Before updating this, verify all assertions are still correct: git grep site.text.assertion_month
   ## Use ISO-8601 format, but feel free to round to the nearest month
-  assertion_month: 2015-09-01
+  assertion_month: 2016-12-01
 
 
 ## Items in devsearches will appear in the search box in the order they

--- a/en/full-node.md
+++ b/en/full-node.md
@@ -163,7 +163,7 @@ have an easy-to-use node.
 * Desktop or laptop hardware running recent versions of Windows, Mac OS
   X, or Linux.
 
-* 70 gigabytes of free disk space
+* {{site.text.bitcoin_datadir_gb}} gigabytes of free disk space
 
 * 2 gigabytes of memory (RAM)
 
@@ -174,7 +174,7 @@ have an easy-to-use node.
   connection you regularly monitor to ensure it doesn't exceed its
   upload limits. It's common for full nodes on high-speed connections to
   use 200 gigabytes upload or more a month. Download usage is around 20
-  gigabytes a month, plus around an additional 50 gigabytes the first
+  gigabytes a month, plus around an additional {{site.text.chain_gb}} gigabytes the first
   time you start your node.
 
 * 6 hours a day that your full node can be left running. (You can do


### PR DESCRIPTION
Thanks for updating the sizes in https://github.com/bitcoin-dot-org/bitcoin.org/pull/1188 .  This extends your work by using some site-wide variables we have for those sizes instead of the plain text, so future updates will be easier.  (I also updated those vars to current values.)

Here's what the page looks like with this merged:

![2015-12-29-103438_620x271_scrot](https://cloud.githubusercontent.com/assets/61096/12036941/8d72ab88-ae18-11e5-80df-6aaefda75fe8.png)

If you merge this here, it will automatically update your PR on Bitcoin.org.
